### PR TITLE
Add missing type casting

### DIFF
--- a/src/Module/GenericMessage.php
+++ b/src/Module/GenericMessage.php
@@ -43,7 +43,7 @@ final class GenericMessage implements Message
 
     public function getRequiredString(string $key): string
     {
-        return $this->getRequired($key);
+        return (string) $this->getRequired($key);
     }
 
     public function getInt(string $key): int


### PR DESCRIPTION
Fix for error:

```
{
    "error": "Landingi\\ModularMonolithBundle\\Module\\GenericMessage::getRequiredString(): Return value must be of type string, Symfony\\Component\\Uid\\UuidV1 returned"
}
```